### PR TITLE
fix https://github.com/roogle-rs/roogle/issues/18

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,12 @@ $ curl -X GET \
       "localhost:8000/search?scope=set:libstd"
 ```
 
+## Query Syntax
+
+- `fn f(type) -> type`
+- `fn (type) -> type`
+- `fn(type) -> type`
+- `(type) -> type`
+
 ## Related Project
 - [cargo-roogle](https://github.com/roogle-rs/cargo-roogle)

--- a/roogle-engine/src/query/parse.rs
+++ b/roogle-engine/src/query/parse.rs
@@ -2,7 +2,7 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_while1},
     character::complete::char,
-    character::complete::{alpha1, alphanumeric1, multispace0},
+    character::complete::{alpha1, alphanumeric1, multispace0, multispace1},
     combinator::{eof, fail, map, not, opt, recognize, value},
     error::{ContextError, ParseError},
     multi::{many0, separated_list0},

--- a/roogle-engine/src/query/parse.rs
+++ b/roogle-engine/src/query/parse.rs
@@ -40,7 +40,7 @@ where
         Some(_) => multispace0(i)?,
         None => multispace0(i)?,
     };
-    let (i, name) = opt(parse_symbol)(i)?;
+    let (i, name) = opt(preceded(multispace1, parse_symbol))(i)?;
     let (i, decl) = opt(parse_function)(i)?;
 
     let query = Query {

--- a/roogle-engine/src/query/parse.rs
+++ b/roogle-engine/src/query/parse.rs
@@ -2,7 +2,7 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_while1},
     character::complete::char,
-    character::complete::{alpha1, alphanumeric1, multispace0, multispace1},
+    character::complete::{alpha1, alphanumeric1, multispace0},
     combinator::{eof, fail, map, not, opt, recognize, value},
     error::{ContextError, ParseError},
     multi::{many0, separated_list0},
@@ -37,7 +37,7 @@ where
 {
     let (i, f) = opt(tag("fn"))(i)?;
     let (i, _) = match f {
-        Some(_) => multispace1(i)?,
+        Some(_) => multispace0(i)?,
         None => multispace0(i)?,
     };
     let (i, name) = opt(parse_symbol)(i)?;


### PR DESCRIPTION
If I understand the parser correctly,

it doesn't support

```
type -> type
```

the bracket is necessary. As #5 said.

so I just change to `multispace0`.

the result:

```sh
curl -X GET \
  -d "fn(Option<Result<T, E>>) -> Result<Option<T>, E>>" \
                                         "localhost:8000/search?scope=set:libstd"
[{"name":"transpose","path":["core","option","Option","transpose"],"link":["core","option","enum.Option.html#method.transpose"],"docs":"Transposes an `Option` of a [`Result`] into a [`Result`] of an `Option`.\n\n[`None`] will be mapped to <code>[Ok]\\([None])</code>.\n<code>[Some]\\([Ok]\\(\\_))
```

and

```sh
curl -X GET \
 -d "fn (Option<Result<T, E>>) -> Result<Option<T>, E>>" \
                                         "localhost:8000/search?scope=set:libstd"
[{"name":"transpose","path":["core","option","Option","transpose"],"link":["core","option","enum.Option.html#method.transpose"],"docs":"Transposes an `Option` of a [`Result`] into a [`Result`] of an `Option`.\n\n[`None`] will be mapped to <code>[Ok]\\([None])</code>.\n<code>[Some]\\([Ok]\\(\\_))</code> 
```

so it seems work properly.

---

to fix the

```
fn(xx)
vs
fn f(xx)
```

I let the space before `f`, instead of after `fn`.

---

to fix #5, I guess add a `alt` may help.

or something like `delimited( opt( char('(') ), xx ,  opt( char(')') )  )`

